### PR TITLE
Check retval of getFunc

### DIFF
--- a/lib/src/util.dart
+++ b/lib/src/util.dart
@@ -68,9 +68,11 @@ class Util {
 
   static int toInt(UtilFunc<ffi.Int32> getFunc) {
     final ptr = ffi.allocate<ffi.Int32>();
-    call(() => getFunc(ptr));
+    int rv;
+    call(() => rv = getFunc(ptr));
     final value = ptr.value;
     ffi.free(ptr);
+    if (rv != sp_return.SP_OK) return null;
     return value;
   }
 }


### PR DESCRIPTION
Return null if getFunc returns other than SP_OK. On my side I had the problem, that the productId and vendorId of a device were shown as a random number, because sp_get_port_usb_vid_pid returned an error